### PR TITLE
Dehardcode Compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
-all: cpuinfo.c
-	gcc -g -o cpuinfo cpuinfo.c
+all: cpuinfo
+
+cpuinfo: cpuinfo.c
+	$(CC) $(CFLAGS)-o $@ $<
+
+clean: rm -f cpuinfo


### PR DESCRIPTION
Used variable for compiler. Generally not best practice to hard code. $(CC) defaults to gcc if not set.
Also included a clean rule.